### PR TITLE
Add #include <linux/types.h>

### DIFF
--- a/include/lidarlite_v3.h
+++ b/include/lidarlite_v3.h
@@ -20,6 +20,8 @@
 #ifndef LIDARLite_v3_h
 #define LIDARLite_v3_h
 
+#include <linux/types.h>
+
 // LIDAR-Lite default I2C device address
 #define LIDARLITE_ADDR_DEFAULT 0x62
 


### PR DESCRIPTION
If not included, __u32, __s32, __u16, __s16 and __u8 are not defined. This is causing errors when user doesn't include linux/types.h before lidarlite_v3.h.